### PR TITLE
Function to fetch a proxy's ProxyAdmin

### DIFF
--- a/badger_utils/proxy_utils.py
+++ b/badger_utils/proxy_utils.py
@@ -8,7 +8,7 @@ from brownie.network.gas.strategies import GasNowStrategy
 from badger_utils.registry.artifacts import artifacts
 
 gas_strategy = GasNowStrategy("rapid")
-
+ADMIN_SLOT = int(0xB53127684A568B3173AE13B9F8A6016E243E63B6E8EE1178D6A717850B5D6103)
 
 def deploy_proxy_admin(deployer: Account) -> Contract:
     abi = artifacts.open_zeppelin["ProxyAdmin"]["abi"]
@@ -59,3 +59,9 @@ def deploy_proxy(
     transaction = deployer.transfer(data=deploy_txn["data"])
 
     return Contract.from_abi(contract_name, transaction.contract_address, logic_abi)
+
+
+def get_proxy_admin(proxy: str) -> str:
+    return web3.toChecksumAddress(
+        web3.eth.getStorageAt(proxy, ADMIN_SLOT).hex()
+    )

--- a/tests/test_proxy_utils.py
+++ b/tests/test_proxy_utils.py
@@ -4,6 +4,7 @@ from brownie import accounts
 from badger_utils.proxy_utils import deploy_proxy
 from badger_utils.proxy_utils import deploy_proxy_admin
 from badger_utils.proxy_utils import deploy_proxy_uninitialized
+from badger_utils.proxy_utils import get_proxy_admin
 from badger_utils.registry.artifacts import artifacts
 
 
@@ -49,3 +50,18 @@ def test_deploy_proxy():
     )
     assert contract.address is not None
     assert accounts[1].gas_used != 0
+
+
+def test_get_proxy_admin():
+    proxy_admin_contract = deploy_proxy_admin(accounts[1])
+    contract = deploy_proxy(
+        "TokenTimelock",
+        logic_abi=artifacts.open_zeppelin["TokenTimelock"]["abi"],
+        logic=proxy_admin_contract.address,
+        proxy_admin=proxy_admin_contract.address,
+        initializer="0x",
+        deployer=accounts[1],
+    )
+    assert contract.address is not None
+    assert accounts[1].gas_used != 0
+    assert get_proxy_admin(contract.address) == proxy_admin_contract.address


### PR DESCRIPTION
This PR closes issue #10 

Added a simple function to fetch a given proxy's ProxyAdmin from its storage. The function was added to the `proxy_utils` and a test was included to ensure its proper behavior. Example of the function's usage:
```
>>> from badger_utils.proxy_utils import get_proxy_admin
>>> get_proxy_admin("0x6dEf55d2e18486B9dDfaA075bc4e4EE0B28c1545")
'0x20dce41acca85e8222d6861aa6d23b6c941777bf'
```

All proxy_utils tests are passing with the new function:
![image](https://user-images.githubusercontent.com/25463788/144282903-f1a0a976-bddc-4564-b6dc-c785aa853142.png)
